### PR TITLE
Refactored Observer Pattern

### DIFF
--- a/jdm.properties
+++ b/jdm.properties
@@ -1,5 +1,5 @@
 #jDiskMark Properties File
-#Sat Dec 26 20:11:44 EST 2020
+#Sun Dec 27 03:29:21 EST 2020
 numOfFiles=50
 blockSequence=SEQUENTIAL
 readTest=true

--- a/src/main/java/edu/touro/mco152/bm/BMObserver.java
+++ b/src/main/java/edu/touro/mco152/bm/BMObserver.java
@@ -6,5 +6,8 @@ package edu.touro.mco152.bm;
  */
 
 public interface BMObserver {
+
     void update();
+
+    boolean getCheckRunFlag();
 }

--- a/src/main/java/edu/touro/mco152/bm/BMSubject.java
+++ b/src/main/java/edu/touro/mco152/bm/BMSubject.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public abstract class BMSubject {
+public class BMSubject {
 
     // bmObservers - A synchronized ArrayList that will store any object of type BMObserver
     private static List<BMObserver> bmObserverRegistry = Collections.synchronizedList(new ArrayList<>());
@@ -13,7 +13,7 @@ public abstract class BMSubject {
      * Adds a BMObserver object to the array
      * @param bmObserver is what we pass in to be added for execution
      */
-    public static void registerObserver(BMObserver bmObserver){
+    public void registerObserver(BMObserver bmObserver){
         bmObserverRegistry.add(bmObserver);
     }
 

--- a/src/main/java/edu/touro/mco152/bm/DiskWorker.java
+++ b/src/main/java/edu/touro/mco152/bm/DiskWorker.java
@@ -3,16 +3,6 @@ package edu.touro.mco152.bm;
 import edu.touro.mco152.bm.command.BMCommandCenter;
 import edu.touro.mco152.bm.command.BMReadActionCommandCenter;
 import edu.touro.mco152.bm.command.BMWriteActionCommandCenter;
-import edu.touro.mco152.bm.externalsys.SlackManager;
-import edu.touro.mco152.bm.persist.DBPersistenceObserver;
-import edu.touro.mco152.bm.persist.DiskRun;
-import edu.touro.mco152.bm.ui.Gui;
-
-import javax.swing.*;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static edu.touro.mco152.bm.App.*;
 
@@ -36,9 +26,10 @@ import static edu.touro.mco152.bm.App.*;
  * DiskWorker is now dependent on SwingWorker via an instance type passed in to its constructor.
  */
 
-public class DiskWorker extends BMSubject {
+public class DiskWorker {
 
     private static UserInterface userInterface;
+    public static BMSubject bmSubject = new BMSubject();
 
     public DiskWorker(UserInterface userInterface) {
         DiskWorker.userInterface = userInterface;
@@ -52,47 +43,24 @@ public class DiskWorker extends BMSubject {
         userInterface.cancelBenchMark(bool);
     }
 
-    static Boolean doBMLogic(){
-
-        /*
-          We 'got here' because: a) End-user clicked 'Start' on the benchmark UI,
-          which triggered the start-benchmark event associated with the App::startBenchmark()
-          method.  b) startBenchmark() then instantiated a DiskWorker, and called
-          its (super class's) execute() method, causing Swing to eventually
-          call this doInBackground() method.
-         */
-
-        Gui.updateLegend();  // init chart legend info
-
-        if (App.autoReset) {
-            App.resetTestData();
-            Gui.resetTestData();
-        }
+    public static Boolean doBMLogic(){
 
         // implement bmCommandCenter that will be assigned the respective Command Classes (i.e - write and read)
         BMCommandCenter bmCommand;
-        // implement DiskRun type to be assigned the diskrun from read and write respectively. It will then be passed to
-        // our GUI and DB Observers
-        DiskRun diskRunTemp;
 
         /*
-          The GUI allows either a write, read, or both types of BMs to be started. They are done serially.
+          The GUI allows either a write, read, or both types of BMs to be started. They are done serially. Only now,
+          we call the GUI from the command classes in order to DiskWorker independent of Gui
          */
 
         // Execute, Register and Notify
         if(App.writeTest) {
-            // Instantiation of bmCommand with
+
             bmCommand = new BMWriteActionCommandCenter(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
             if(bmCommand.doBMCommand()){
-                diskRunTemp = bmCommand.getDiskRun();
-                //Persist info about the Write BM Run (e.g. into Derby Database)
-                DiskWorker.registerObserver(new DBPersistenceObserver(diskRunTemp));
-
-                Gui gui = new Gui(diskRunTemp);
-                DiskWorker.registerObserver(gui);
+                BMSubject.notifyObservers();
             }
 
-            notifyObservers();
         }
 
         /*
@@ -103,30 +71,16 @@ public class DiskWorker extends BMSubject {
 
         // try renaming all files to clear cache
         if (App.readTest && App.writeTest && !userInterface.isBenchMarkCancelled()) {
-            JOptionPane.showMessageDialog(Gui.mainFrame,
-                    "For valid READ measurements please clear the disk cache by\n" +
-                            "using the included RAMMap.exe or flushmem.exe utilities.\n" +
-                            "Removable drives can be disconnected and reconnected.\n" +
-                            "For system drives use the WRITE and READ operations \n" +
-                            "independantly by doing a cold reboot after the WRITE",
-                    "Clear Disk Cache Now", JOptionPane.PLAIN_MESSAGE);
+            userInterface.showMessagePopUp();
         }
 
         // Execute and Register. Then instantiate for slack and send a message when read is complete and Notify.
         if (App.readTest) {
             bmCommand = new BMReadActionCommandCenter(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
             if(bmCommand.doBMCommand()){
-                diskRunTemp = bmCommand.getDiskRun();
-                //Persist info about the Write BM Run (e.g. into Derby Database)
-                DiskWorker.registerObserver(new DBPersistenceObserver(diskRunTemp));
-
-                Gui gui = new Gui(diskRunTemp);
-                DiskWorker.registerObserver(gui);
+                BMSubject.notifyObservers();
             }
-            SlackManager slackManager = new SlackManager("BadBM");
-            slackManager.setMessage(":smile: Benchmark completed");
-            DiskWorker.registerObserver(slackManager);
-            notifyObservers();
+
         }
 
         App.nextMarkNumber += App.numOfMarks;

--- a/src/main/java/edu/touro/mco152/bm/GUIBenchmark.java
+++ b/src/main/java/edu/touro/mco152/bm/GUIBenchmark.java
@@ -76,13 +76,37 @@ public class GUIBenchmark extends SwingWorker<Boolean, DiskMark> implements User
         return cancel(bool);
     }
 
+    @Override
+    public void showMessagePopUp() {
+        JOptionPane.showMessageDialog(Gui.mainFrame,
+                "For valid READ measurements please clear the disk cache by\n" +
+                        "using the included RAMMap.exe or flushmem.exe utilities.\n" +
+                        "Removable drives can be disconnected and reconnected.\n" +
+                        "For system drives use the WRITE and READ operations \n" +
+                        "independantly by doing a cold reboot after the WRITE",
+                "Clear Disk Cache Now", JOptionPane.PLAIN_MESSAGE);
+    }
+
 
     /**
      * Called by WorkerThreads from execute. What's defined here will be executed by the threads.
      * @return a boolean to it's caller from SwingWorker
      */
     @Override
-    protected Boolean doInBackground(){
+    public Boolean doInBackground(){
+        /*
+          We 'got here' because: a) End-user clicked 'Start' on the benchmark UI,
+          which triggered the start-benchmark event associated with the App::startBenchmark()
+          method.  b) startBenchmark() then instantiated a DiskWorker, and passed it an instance of this class.
+          Then, App.java called DiskWorker.executionDelegate which will call executeBenchmark in this class.
+         */
+        Gui.updateLegend();  // init chart legend info
+
+        if (App.autoReset) {
+            App.resetTestData();
+            Gui.resetTestData();
+        }
+
         return DiskWorker.doBMLogic();
     }
 

--- a/src/main/java/edu/touro/mco152/bm/UserInterface.java
+++ b/src/main/java/edu/touro/mco152/bm/UserInterface.java
@@ -14,4 +14,6 @@ public interface UserInterface {
 
     boolean cancelBenchMark(boolean bool);
 
+    void showMessagePopUp();
+
 }

--- a/src/main/java/edu/touro/mco152/bm/command/BMWriteActionCommandCenter.java
+++ b/src/main/java/edu/touro/mco152/bm/command/BMWriteActionCommandCenter.java
@@ -19,6 +19,7 @@ import static edu.touro.mco152.bm.App.*;
 import static edu.touro.mco152.bm.App.msg;
 import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
 
+
 /**
  * implement our BMCommandCenter to make our writeBM class an object of type BMCommandCenter
  */
@@ -161,6 +162,10 @@ public class BMWriteActionCommandCenter implements BMCommandCenter {
             run.setEndTime(new Date());
         } // END outer loop for specified duration (number of 'marks') for WRITE bench mark
 
+        //Persist info about the Write BM Run (e.g. into Derby Database)
+        DiskWorker.bmSubject.registerObserver(new DBPersistenceObserver(run));
+
+        DiskWorker.bmSubject.registerObserver(new Gui(run));
         return true;
     }
 

--- a/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
+++ b/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
@@ -24,6 +24,7 @@ import java.io.IOException;
  */
 public class SlackManager implements BMObserver {
     private static Slack slack = null;  // obtain/keep one copy of expensive item
+    public boolean checkRunFlag;
     /**
      * Token for use with Slack API, representing info about our bot/app/channel.
      * If the token is a bot token, it starts with `xoxb-` while if it's a user token, it starts with `xoxp-`
@@ -58,6 +59,7 @@ public class SlackManager implements BMObserver {
                 System.err.println("SlackManager: Problem with auto-validation of Slack: "
                         + testResponse.getError());
             }
+            checkRunFlag = false;
         } catch (IOException | SlackApiException exc) {
             System.err.println("SlackManager: Problem with auto-validation of Slack");
             exc.printStackTrace();
@@ -113,5 +115,11 @@ public class SlackManager implements BMObserver {
         // Boolean worked = slackmgr.postMsg2OurChannel(":cry: Benchmark failed");
         Boolean worked = postMsg2OurChannel(msg);
         System.err.println("Returned boolean from sending msg is " + worked);
+        checkRunFlag = true;
+    }
+
+    @Override
+    public boolean getCheckRunFlag() {
+        return checkRunFlag;
     }
 }

--- a/src/main/java/edu/touro/mco152/bm/persist/DBPersistenceObserver.java
+++ b/src/main/java/edu/touro/mco152/bm/persist/DBPersistenceObserver.java
@@ -11,9 +11,11 @@ import javax.persistence.EntityManager;
 public class DBPersistenceObserver implements BMObserver {
 
     DiskRun diskRun;
+    public boolean checkRunFlag;
 
     public DBPersistenceObserver(DiskRun diskRun){
         this.diskRun = diskRun;
+        checkRunFlag = false;
     }
 
     @Override
@@ -22,5 +24,11 @@ public class DBPersistenceObserver implements BMObserver {
         em.getTransaction().begin();
         em.persist(diskRun);
         em.getTransaction().commit();
+        checkRunFlag = true;
+    }
+
+    @Override
+    public boolean getCheckRunFlag() {
+        return checkRunFlag;
     }
 }

--- a/src/main/java/edu/touro/mco152/bm/ui/Gui.java
+++ b/src/main/java/edu/touro/mco152/bm/ui/Gui.java
@@ -31,9 +31,11 @@ public final class Gui implements BMObserver {
     public static JProgressBar progressBar = null;
     public static RunPanel runPanel = null;
     public DiskRun diskRun;
+    public boolean checkRunFlag;
 
     public Gui(DiskRun diskRun){
         this.diskRun = diskRun;
+        checkRunFlag = false;
     }
 
     public static ChartPanel createChartPanel() {
@@ -148,5 +150,11 @@ public final class Gui implements BMObserver {
     @Override
     public void update() {
         runPanel.addRun(diskRun);
+        checkRunFlag = true;
+    }
+
+    @Override
+    public boolean getCheckRunFlag() {
+        return checkRunFlag;
     }
 }

--- a/src/test/java/edu/touro/mco152/bm/command/ObserverTest.java
+++ b/src/test/java/edu/touro/mco152/bm/command/ObserverTest.java
@@ -1,0 +1,35 @@
+package edu.touro.mco152.bm.command;
+
+import edu.touro.mco152.bm.App;
+import edu.touro.mco152.bm.GUIBenchmark;
+import edu.touro.mco152.bm.ui.Gui;
+import edu.touro.mco152.bm.ui.MainFrame;
+import java.io.File;
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class ObserverTest {
+
+    WriteReadCommandTest writeReadCommandTest = new WriteReadCommandTest();
+
+
+    @Test
+    public void writeObservers(){
+        writeReadCommandTest.writeCommand();
+
+        
+
+    }
+
+    @Test
+    public void readObservers(){
+
+    }
+
+
+}

--- a/src/test/java/edu/touro/mco152/bm/command/WriteReadCommandTest.java
+++ b/src/test/java/edu/touro/mco152/bm/command/WriteReadCommandTest.java
@@ -1,9 +1,7 @@
 package edu.touro.mco152.bm.command;
 
 import edu.touro.mco152.bm.App;
-import edu.touro.mco152.bm.DiskWorker;
 import edu.touro.mco152.bm.GUIBenchmark;
-import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 import edu.touro.mco152.bm.ui.MainFrame;
 import java.io.File;

--- a/src/test/java/edu/touro/mco152/bm/command/WriteReadCommandTest.java
+++ b/src/test/java/edu/touro/mco152/bm/command/WriteReadCommandTest.java
@@ -1,17 +1,25 @@
 package edu.touro.mco152.bm.command;
 
 import edu.touro.mco152.bm.App;
+import edu.touro.mco152.bm.DiskWorker;
+import edu.touro.mco152.bm.GUIBenchmark;
+import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 import edu.touro.mco152.bm.ui.MainFrame;
 import java.io.File;
 import java.util.Properties;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class BMReadCommandTest {
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WriteReadCommandTest {
+
+    public GUIBenchmark guiBenchmark = new GUIBenchmark();
+    public int numOfMark = 50;
+    public int numOfBlocks = 64;
+    public int blockSizeKb = 64;
 
     @BeforeAll
     /**
@@ -49,9 +57,22 @@ public class BMReadCommandTest {
     }
 
     @Test
-    public void testExecute(){
+    public void writeCommand(){
+        setupDefaultAsPerProperties();
 
+        BMWriteActionCommandCenter bmWriteActionCommandCenter = new BMWriteActionCommandCenter(guiBenchmark, numOfMark, numOfBlocks, blockSizeKb, App.blockSequence);
+
+        assertTrue(bmWriteActionCommandCenter.doBMCommand());
 
     }
 
+    @Test
+    public void readCommand(){
+        setupDefaultAsPerProperties();
+
+        BMReadActionCommandCenter bmReadActionCommandCenter = new BMReadActionCommandCenter(guiBenchmark, numOfMark, numOfBlocks, blockSizeKb, App.blockSequence);
+
+        assertTrue(bmReadActionCommandCenter.doBMCommand());
+
+    }
 }


### PR DESCRIPTION
(1) DiskWorker.java is no longer dependent on GUI, DBPersistenceObserver and SlackManager.
(2) UserInterface now has a showMessagePopUp() method that must be implemented and defined.
(3) Moved JOptionPane pop-up to GUIBenchmark.java.
(4) Observer registrations have been moved to their respective command classes.
(5) SlackManager will be assigned its success/failure message in BMReadActionCommandCenter.java
(6) Test added for command classes