### PR TITLE
Refactoring Observer Pattern 

### DIFF
--- a/jdm.properties
+++ b/jdm.properties
@@ -1,5 +1,5 @@
 #jDiskMark Properties File
-#Tue Dec 29 04:13:01 EST 2020
+#Tue Dec 29 08:02:33 EST 2020
 numOfFiles=50
 blockSequence=SEQUENTIAL
 readTest=true

--- a/jdm.properties
+++ b/jdm.properties
@@ -1,5 +1,5 @@
 #jDiskMark Properties File
-#Tue Dec 29 08:02:33 EST 2020
+#Tue Dec 29 19:10:30 EST 2020
 numOfFiles=50
 blockSequence=SEQUENTIAL
 readTest=true

--- a/jdm.properties
+++ b/jdm.properties
@@ -1,5 +1,5 @@
 #jDiskMark Properties File
-#Tue Dec 29 19:10:30 EST 2020
+#Thu Dec 31 05:46:13 EST 2020
 numOfFiles=50
 blockSequence=SEQUENTIAL
 readTest=true

--- a/src/main/java/edu/touro/mco152/bm/BMObserver.java
+++ b/src/main/java/edu/touro/mco152/bm/BMObserver.java
@@ -8,4 +8,6 @@ package edu.touro.mco152.bm;
 public interface BMObserver {
 
     void update();
+
+    Boolean isUpdated();
 }

--- a/src/main/java/edu/touro/mco152/bm/CommandExecutor.java
+++ b/src/main/java/edu/touro/mco152/bm/CommandExecutor.java
@@ -6,23 +6,29 @@ import edu.touro.mco152.bm.persist.DBPersistenceObserver;
 import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 public class CommandExecutor {
 
     private final BMCommandCenter bmCommandCenter;
-
     private final DiskRun run;
-
     private SlackManager slackManager;
+
+    public boolean wasExecuted;
 
     // Implement bmCommandCenter that will be assigned the respective Command Classes (i.e - write and read)
     // NOTE: In the real world, the BMCommandCenter object ref will be assigned via set method.
     public CommandExecutor(BMCommandCenter bmCommandCenter){
         this.bmCommandCenter = bmCommandCenter;
         run = bmCommandCenter.getDiskRun();
+        wasExecuted = false;
     }
 
     public boolean executeLogicDelegate(){
         if(bmCommandCenter.execute()){
+            wasExecuted = true;
             if( !bmCommandCenter.message.isEmpty() ){
                 slackManager.setMessage(bmCommandCenter.message);
             }
@@ -54,6 +60,10 @@ public class CommandExecutor {
             slackManager = new SlackManager("BadBM", run);
             bmCommandCenter.registerObserver(slackManager);
         }
+    }
+
+    public ArrayList<BMObserver> getObserverDelegate(){
+        return new ArrayList<>(bmCommandCenter.getBmObserverRegistry());
     }
 
 }

--- a/src/main/java/edu/touro/mco152/bm/CommandExecutor.java
+++ b/src/main/java/edu/touro/mco152/bm/CommandExecutor.java
@@ -1,4 +1,11 @@
 package edu.touro.mco152.bm;
+/**
+ * An object that acts as a broker between buyer (Client) and seller (BMCommandObject).
+ *
+ * We need a way to execute generic commands and register observers without compromise.
+ * Our new CommandExecutor class will allow us to run any kind of command object we
+ * please, provided we have that object extend BMCommandObject
+ */
 
 import edu.touro.mco152.bm.command.BMCommandCenter;
 import edu.touro.mco152.bm.externalsys.SlackManager;
@@ -7,29 +14,40 @@ import edu.touro.mco152.bm.persist.DiskRun;
 import edu.touro.mco152.bm.ui.Gui;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 public class CommandExecutor {
 
     private final BMCommandCenter bmCommandCenter;
-    private final DiskRun run;
     private SlackManager slackManager;
 
+    // boolean flag checker if shes
     public boolean wasExecuted;
 
     // Implement bmCommandCenter that will be assigned the respective Command Classes (i.e - write and read)
     // NOTE: In the real world, the BMCommandCenter object ref will be assigned via set method.
     public CommandExecutor(BMCommandCenter bmCommandCenter){
         this.bmCommandCenter = bmCommandCenter;
-        run = bmCommandCenter.getDiskRun();
         wasExecuted = false;
     }
 
+    /**
+     * The client who instantiates this object should only know how to call execute with elegance,
+     * this method satisfies the requirement and is designed to be called as a condition to an if-statement.
+     * Essentially, this is a delegate method that calls the executor of our (command) generic object, after
+     * it will do any preliminary tasks in case it needs to prepare an observer with a benchmark status,
+     * (Like we do here for slackManager).
+     *
+     * @return A boolean to the (recommended) to the client object.
+     */
     public boolean executeLogicDelegate(){
         if(bmCommandCenter.execute()){
+            // check flag set to true - used in tests
             wasExecuted = true;
+            // Here, we just want to check if the value of message was set to anything. If it was, then we
+            // have some preliminary work to do before whatever class that instantiates this object has to call notify.
             if( !bmCommandCenter.message.isEmpty() ){
+                // All we're doing here, is sending whatever this message may be to be stored in slackManager.
+                // Cool! and it works? nope.
                 slackManager.setMessage(bmCommandCenter.message);
             }
             return true;
@@ -37,22 +55,39 @@ public class CommandExecutor {
         return false;
     }
 
+    /**
+     * It is recommended that the client calls this method in the body of the if-statement executor.
+     * This is a delegate method used by the client to call notify int the observable command class.
+     */
     public void notifyObserversDelegate(){
         bmCommandCenter.notifyObservers();
     }
 
+    /**
+     * The client must calls this method before calling execute. Whatever observer object we pass in
+     * will be called when the client reaches notifyObserversDelegate. But remember: nothing will be
+     * notified if you do not call this BEFORE executeLogicDelegate.
+     */
     public void registerObserverDelegate(BMObserver observer){
         bmCommandCenter.registerObserver(observer);
     }
 
     // Default registration
 
-    public void defaultWriteRegistration(){
+    /**
+     * Default registration for the write logic portion. This is only here to help tidy up dependencies
+     * from the client. Makes use of
+     */
+    public void defaultWriteRegistration(DiskRun run){
         bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
         bmCommandCenter.registerObserver(new Gui(run));
     }
 
-    public void defaultReadRegistration(){
+    /**
+     * Default registration for the read logic portion. This is only here to help tidy up dependencies
+     * from the client.
+     */
+    public void defaultReadRegistration(DiskRun run){
         bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
         bmCommandCenter.registerObserver(new Gui(run));
         // Put if here for Max speed > 3% of avg speed
@@ -62,6 +97,14 @@ public class CommandExecutor {
         }
     }
 
+    /**
+     * Client: Hey man, sometimes I might need a list of your observers. (customer)
+     * CommandExecutor: Okay. Hey, BMCommandObject. I want a list of observers (retailer)
+     * BMCommandObject: Yeah? Ok here you go (wholesaler sells wholesale)
+     * CommandExecutor: Hey, Client. I have those observers you wanted (retailer sells retail - gives observers)
+     *
+     * @return An object of the List interface. In this case an ArrayList.
+     */
     public ArrayList<BMObserver> getObserverDelegate(){
         return new ArrayList<>(bmCommandCenter.getBmObserverRegistry());
     }

--- a/src/main/java/edu/touro/mco152/bm/CommandExecutor.java
+++ b/src/main/java/edu/touro/mco152/bm/CommandExecutor.java
@@ -1,8 +1,6 @@
 package edu.touro.mco152.bm;
 
 import edu.touro.mco152.bm.command.BMCommandCenter;
-import edu.touro.mco152.bm.command.BMReadActionCommandCenter;
-import edu.touro.mco152.bm.command.BMWriteActionCommandCenter;
 import edu.touro.mco152.bm.externalsys.SlackManager;
 import edu.touro.mco152.bm.persist.DBPersistenceObserver;
 import edu.touro.mco152.bm.persist.DiskRun;
@@ -10,81 +8,52 @@ import edu.touro.mco152.bm.ui.Gui;
 
 public class CommandExecutor {
 
-    private final UserInterface userInterface;
-    public final String command;
+    private final BMCommandCenter bmCommandCenter;
 
-    // Implement bmCommandCenter that will be assigned the respective Command Classes (i.e - write and read)
-    // NOTE: In the real world, the BMCommand Interface ref will be assigned via set method.
-    private BMCommandCenter bmCommandCenter;
-
-    private int numOfMarks = App.numOfMarks;
-    private int numOfBlocks = App.numOfBlocks;
-    private int blockSizeKb = App.blockSizeKb;
-    private DiskRun.BlockSequence blockSequence = App.blockSequence;
-
-    private DiskRun run;
+    private final DiskRun run;
 
     private SlackManager slackManager;
 
-    public CommandExecutor(UserInterface userInterface, String command){
-        this.userInterface = userInterface;
-        this.command = command;
+    // Implement bmCommandCenter that will be assigned the respective Command Classes (i.e - write and read)
+    // NOTE: In the real world, the BMCommandCenter object ref will be assigned via set method.
+    public CommandExecutor(BMCommandCenter bmCommandCenter){
+        this.bmCommandCenter = bmCommandCenter;
+        run = bmCommandCenter.getDiskRun();
     }
 
-    public void setDefaultBMParams(){
-        switch (command.toLowerCase()){
-            case "write":
-                bmCommandCenter = new BMWriteActionCommandCenter(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
-                run = bmCommandCenter.getDiskRun();
-                //Persist info about the Write BM Run (e.g. into Derby Database)
-                bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
-                bmCommandCenter.registerObserver(new Gui(run));
-            case "read":
-                bmCommandCenter = new BMReadActionCommandCenter(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
-                run = bmCommandCenter.getDiskRun();
-                //Persist info about the Write BM Run (e.g. into Derby Database)
-                bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
-                bmCommandCenter.registerObserver(new Gui(run));
-                // Put if here for Max speed > 3% of avg speed
-                if(run.getRunMax() > (run.getRunAvg() * 0.03)){
-                    slackManager = new SlackManager("BadBM", run);
-                    bmCommandCenter.registerObserver(slackManager);
-                }
+    public boolean executeLogicDelegate(){
+        if(bmCommandCenter.execute()){
+            if( !bmCommandCenter.message.isEmpty() ){
+                slackManager.setMessage(bmCommandCenter.message);
+            }
+            return true;
         }
+        return false;
     }
 
-    public void setCustomBMParams(int numOfMarks, int numOfBlocks, int blockSizeKb, DiskRun.BlockSequence blockSequence){
-        switch (command.toLowerCase()){
-            case "write":
-                bmCommandCenter = new BMWriteActionCommandCenter(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
-                run = bmCommandCenter.getDiskRun();
-                //Persist info about the Write BM Run (e.g. into Derby Database)
-                bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
-                bmCommandCenter.registerObserver(new Gui(run));
-            case "read":
-                bmCommandCenter = new BMReadActionCommandCenter(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
-                run = bmCommandCenter.getDiskRun();
-                //Persist info about the Write BM Run (e.g. into Derby Database)
-                bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
-                bmCommandCenter.registerObserver(new Gui(run));
-                // Put if here for Max speed > 3% of avg speed
-                if(run.getRunMax() > (run.getRunAvg() * 0.03)){
-                    slackManager = new SlackManager("BadBM", run);
-                    bmCommandCenter.registerObserver(slackManager);
-                }
-        }
-    }
-
-    public boolean executeBMCommandObject(){
-        bmCommandCenter.execute();
-        if( !bmCommandCenter.message.isEmpty() ){
-            slackManager.setMessage(bmCommandCenter.message);
-        }
-        return true;
-    }
-
-    public void notifyCommandObservers(){
+    public void notifyObserversDelegate(){
         bmCommandCenter.notifyObservers();
+    }
+
+    public void registerObserverDelegate(BMObserver observer){
+        bmCommandCenter.registerObserver(observer);
+    }
+
+    // Default registration
+
+    public void defaultWriteRegistration(){
+        bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
+        bmCommandCenter.registerObserver(new Gui(run));
+    }
+
+    public void defaultReadRegistration(){
+        bmCommandCenter.registerObserver(new DBPersistenceObserver(run));
+        bmCommandCenter.registerObserver(new Gui(run));
+        // Put if here for Max speed > 3% of avg speed
+        if(run.getRunMax() > (run.getRunAvg() * 0.03)){
+            slackManager = new SlackManager("BadBM", run);
+            bmCommandCenter.registerObserver(slackManager);
+        }
     }
 
 }

--- a/src/main/java/edu/touro/mco152/bm/DiskWorker.java
+++ b/src/main/java/edu/touro/mco152/bm/DiskWorker.java
@@ -6,22 +6,19 @@ import edu.touro.mco152.bm.command.BMWriteActionCommandCenter;
 
 /**
  * Run the disk benchmarking as a Swing-compliant thread (only one of these threads can run at
- * once.) Cooperates with Swing to provide and make use of interim and final progress and
- * information, which is also recorded as needed to the persistence store, and log.
+ * once.) Cooperates with UserInterface to provide and make use of interim and final progress and
+ * information, which is also recorded as needed to the the observers, persistence store, and log.
  * <p>
  * Depends on static values that describe the benchmark to be done having been set in App and Gui classes.
  * The DiskRun class is used to keep track of and persist info about each benchmark at a higher level (a run),
  * while the DiskMark class described each iteration's result, which is displayed by the UI as the benchmark run
  * progresses.
  * <p>
- * This class only knows how to do 'read' or 'write' disk benchmarks. It is instantiated in the
- * startBenchmark() method.
+ * This class only knows how to execute 'read' or 'write' disk benchmarks via the CommandExecutor class. It is
+ * instantiated in the startBenchmark() method.
  * <p>
- * This class has one purpose, to provide instructions to run a benchmark. We instantiate this class with an object
- * of type SwingWorker and UserInterface (GUIBenchMark), which will be used in doBMLogic to call instruction to
- * GUIBenchMark::isBenchMarkCancelled, ::executeBenchMark, ::cancelBenchMark, ::publishToGUI and ::provideProgress.
  * Instead of SwingWorker being dependent on DiskWorker (a class with an entirely different responsibility),
- * DiskWorker is now dependent on SwingWorker via an instance type passed in to its constructor.
+ * DiskWorker is now dependent on SwingWorker via a UserInterface type passed in to this classes constructor.
  */
 
 public class DiskWorker {
@@ -32,22 +29,38 @@ public class DiskWorker {
         DiskWorker.userInterface = userInterface;
     }
 
+    /**
+     * Called from App.startBenchmark(), this delegate-execution method will make a call to the
+     * userInterface execute method.
+     */
     public void executionDelegate() {
         userInterface.executeBenchMark();
     }
 
+    /**
+     * Called from App.cancelBenchmark(), this delegate-execution canceller will make a call to the
+     * userInterface cancel method.
+     */
     public void cancelDelegate(Boolean bool) {
         userInterface.cancelBenchMark(bool);
     }
 
+    /**
+     * Called from UserInterface's doInBackground (using SwingWorker) or executeBenchMark (without using SwingWorker)
+     * method. This static method defines the master-plan of running benchmark logic. It puts CommandExecutor to use by
+     * giving it an instance like BMWriteActionCommandCenter and BMReadActionCommandCenter.
+     *
+     * @return a boolean to doInBackground (when using SwingWorker) or to executeBenchMark (when not using SwingWorker).
+     */
     public static Boolean doBMLogic(){
 
+        // bmCommand will be interchangeable with BMWriteActionCommandCenter and BMReadActionCommandCenter
         BMCommandCenter bmCommand;
         CommandExecutor commandExecutor;
 
         /*
           The GUI allows either a write, read, or both types of BMs to be started. They are done serially. Only now,
-          we call the GUI from the command classes in order to DiskWorker independent of Gui
+          we call the GUI from the command objects.
          */
 
         // Execute, Register and Notify
@@ -56,7 +69,7 @@ public class DiskWorker {
                     App.blockSequence);
             commandExecutor = new CommandExecutor(bmCommand);
 
-            commandExecutor.defaultWriteRegistration();
+            commandExecutor.defaultWriteRegistration(bmCommand.getDiskRun());
             if(commandExecutor.executeLogicDelegate()){
                 commandExecutor.notifyObserversDelegate();
             }
@@ -72,12 +85,14 @@ public class DiskWorker {
             userInterface.showMessagePopUp();
         }
 
-        // Execute and Register. Then instantiate for slack and send a message when read is complete and Notify.
+        // Execute and Register. Then instantiate for slack and provide a message when read is complete and Notifies.
         if (App.readTest) {
+
             bmCommand = new BMReadActionCommandCenter(userInterface, App.numOfMarks, App.numOfBlocks, App.blockSizeKb,
                     App.blockSequence);
             commandExecutor = new CommandExecutor(bmCommand);
-            commandExecutor.defaultReadRegistration();
+            commandExecutor.defaultReadRegistration(bmCommand.getDiskRun());
+
             if(commandExecutor.executeLogicDelegate()){
                 commandExecutor.notifyObserversDelegate();
             }

--- a/src/main/java/edu/touro/mco152/bm/DiskWorker.java
+++ b/src/main/java/edu/touro/mco152/bm/DiskWorker.java
@@ -1,5 +1,9 @@
 package edu.touro.mco152.bm;
 
+import edu.touro.mco152.bm.command.BMCommandCenter;
+import edu.touro.mco152.bm.command.BMReadActionCommandCenter;
+import edu.touro.mco152.bm.command.BMWriteActionCommandCenter;
+
 /**
  * Run the disk benchmarking as a Swing-compliant thread (only one of these threads can run at
  * once.) Cooperates with Swing to provide and make use of interim and final progress and
@@ -38,6 +42,7 @@ public class DiskWorker {
 
     public static Boolean doBMLogic(){
 
+        BMCommandCenter bmCommand;
         CommandExecutor commandExecutor;
 
         /*
@@ -47,10 +52,13 @@ public class DiskWorker {
 
         // Execute, Register and Notify
         if(App.writeTest) {
-            commandExecutor = new CommandExecutor(userInterface, "write");
-            commandExecutor.setDefaultBMParams();
-            if(commandExecutor.executeBMCommandObject()){
-                commandExecutor.notifyCommandObservers();
+            bmCommand = new BMWriteActionCommandCenter(userInterface, App.numOfMarks, App.numOfBlocks, App.blockSizeKb,
+                    App.blockSequence);
+            commandExecutor = new CommandExecutor(bmCommand);
+
+            commandExecutor.defaultWriteRegistration();
+            if(commandExecutor.executeLogicDelegate()){
+                commandExecutor.notifyObserversDelegate();
             }
         }
 
@@ -66,10 +74,12 @@ public class DiskWorker {
 
         // Execute and Register. Then instantiate for slack and send a message when read is complete and Notify.
         if (App.readTest) {
-            commandExecutor = new CommandExecutor(userInterface, "read");
-            commandExecutor.setDefaultBMParams();
-            if(commandExecutor.executeBMCommandObject()){
-                commandExecutor.notifyCommandObservers();
+            bmCommand = new BMReadActionCommandCenter(userInterface, App.numOfMarks, App.numOfBlocks, App.blockSizeKb,
+                    App.blockSequence);
+            commandExecutor = new CommandExecutor(bmCommand);
+            commandExecutor.defaultReadRegistration();
+            if(commandExecutor.executeLogicDelegate()){
+                commandExecutor.notifyObserversDelegate();
             }
         }
 

--- a/src/main/java/edu/touro/mco152/bm/TestObserver.java
+++ b/src/main/java/edu/touro/mco152/bm/TestObserver.java
@@ -2,18 +2,19 @@ package edu.touro.mco152.bm;
 
 public class TestObserver implements BMObserver{
 
-    private boolean updateFlag;
+    private boolean hasBeenUpdated;
 
     public TestObserver(){
-        updateFlag = false;
+        hasBeenUpdated = false;
     }
 
     @Override
     public void update() {
-        updateFlag = true;
+        hasBeenUpdated = true;
     }
 
-    public boolean isUpdated(){
-        return updateFlag;
+    @Override
+    public Boolean isUpdated() {
+        return hasBeenUpdated;
     }
 }

--- a/src/main/java/edu/touro/mco152/bm/command/BMCommandCenter.java
+++ b/src/main/java/edu/touro/mco152/bm/command/BMCommandCenter.java
@@ -64,4 +64,8 @@ public abstract class BMCommandCenter {
             bmObserverTemp.update();
         }
     }
+
+    public List<BMObserver> getBmObserverRegistry(){
+        return bmObserverRegistry;
+    }
 }

--- a/src/main/java/edu/touro/mco152/bm/command/BMCommandCenter.java
+++ b/src/main/java/edu/touro/mco152/bm/command/BMCommandCenter.java
@@ -9,9 +9,10 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * BMCommandCenter is an abstract class that our read/write command classes will extend.
- *
- * CommandExecutor instantiates a command object and calls it's execute method.
+ * BMCommandCenter is an abstract class that is capable of reading or writing benchmarks.
+ * However, it must be extended and have its abstract methods defined. This Command object must be
+ * instantiated with the essentials: A UserInterface and a couple of integers that are vital for a
+ * successful benchmark execution. This class has its capabilities with Read and Write classes.
  */
 public abstract class BMCommandCenter {
 
@@ -22,6 +23,8 @@ public abstract class BMCommandCenter {
     protected int numOfMarks, numOfBlocks, blockSizeKb;
     protected DiskRun.BlockSequence blockSequence;
     protected DiskRun run;
+
+    // variable assigned a message for preliminary status update.
     public String message = "";
 
     public BMCommandCenter(UserInterface userInterface, int numOfMarks, int numOfBlocks, int blockSizeKb, DiskRun.BlockSequence blockSequence){
@@ -33,6 +36,7 @@ public abstract class BMCommandCenter {
         run = new DiskRun(DiskRun.IOMode.WRITE, this.blockSequence);
     }
 
+    // Abstracts must be defined in child class
     public abstract boolean execute();
     public abstract void undoBMCommand();
     public abstract DiskRun getDiskRun();
@@ -65,6 +69,12 @@ public abstract class BMCommandCenter {
         }
     }
 
+    /**
+     * Client: Hey man, I need a list of your observers. (A buyer)
+     * BMCommandObject: Here you go. (gives observers)
+     *
+     * @return An object of the List interface. In this case an ArrayList.
+     */
     public List<BMObserver> getBmObserverRegistry(){
         return bmObserverRegistry;
     }

--- a/src/main/java/edu/touro/mco152/bm/command/BMCommandCenter.java
+++ b/src/main/java/edu/touro/mco152/bm/command/BMCommandCenter.java
@@ -9,8 +9,9 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * BMCommandCenter is an interface that our read/write benchmark will implement.
- * Diskworker instantiates a command object and calls it's execute method
+ * BMCommandCenter is an abstract class that our read/write command classes will extend.
+ *
+ * CommandExecutor instantiates a command object and calls it's execute method.
  */
 public abstract class BMCommandCenter {
 
@@ -58,7 +59,7 @@ public abstract class BMCommandCenter {
      * by one notifies each of them by calling their update()
      */
     public void notifyObservers(){
-        // Notify BMObservers by their .updateMethods
+        // Notify BMObservers by their .update method
         for (BMObserver bmObserverTemp: bmObserverRegistry) {
             bmObserverTemp.update();
         }

--- a/src/main/java/edu/touro/mco152/bm/command/BMWriteActionCommandCenter.java
+++ b/src/main/java/edu/touro/mco152/bm/command/BMWriteActionCommandCenter.java
@@ -16,8 +16,13 @@ import static edu.touro.mco152.bm.App.*;
 import static edu.touro.mco152.bm.App.msg;
 import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
 
+
 /**
- * implement our BMCommandCenter to make our writeBM class an object of type BMCommandCenter
+ * This class has one purpose, to provide instructions for writing a benchmark. We instantiate this class with an object
+ * of type SwingWorker and UserInterface (GUIBenchMark), which will be used in doBMLogic to call instruction to
+ * GUIBenchMark::isBenchMarkCancelled, ::executeBenchMark, ::publishToGUI and ::provideProgress.
+ *
+ * Extend our BMCommandCenter to make our writeBM class an object of type BMCommandCenter
  */
 public class BMWriteActionCommandCenter extends BMCommandCenter {
 
@@ -25,6 +30,14 @@ public class BMWriteActionCommandCenter extends BMCommandCenter {
         super(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);
     }
 
+    /**
+     * At the end of the day, execution itself is dependant on one method... this one.
+     * No longer do we reference important data so dependant and 'tightly coupled'. Now,
+     * The essential variables needed will come defined from the client who doesn't mind
+     * being tied down to App.java in order for it to set them independently.
+     *
+     * @return a boolean to an if-statement condition in the CommandExecutor.executeLogicDelegate
+     */
     @Override
     public boolean execute() {
 
@@ -155,6 +168,10 @@ public class BMWriteActionCommandCenter extends BMCommandCenter {
 
     }
 
+    /**
+     * Client should be able to call for a DiskRun when one needed (Observers take DiskRuns as constructor params)
+     * @return the data for a single run.
+     */
     @Override
     public DiskRun getDiskRun() {
         return run;

--- a/src/main/java/edu/touro/mco152/bm/command/BMWriteActionCommandCenter.java
+++ b/src/main/java/edu/touro/mco152/bm/command/BMWriteActionCommandCenter.java
@@ -16,13 +16,10 @@ import static edu.touro.mco152.bm.App.*;
 import static edu.touro.mco152.bm.App.msg;
 import static edu.touro.mco152.bm.DiskMark.MarkType.WRITE;
 
-
 /**
  * implement our BMCommandCenter to make our writeBM class an object of type BMCommandCenter
  */
 public class BMWriteActionCommandCenter extends BMCommandCenter {
-
-
 
     public BMWriteActionCommandCenter(UserInterface userInterface, int numOfMarks, int numOfBlocks, int blockSizeKb, DiskRun.BlockSequence blockSequence){
         super(userInterface, numOfMarks, numOfBlocks, blockSizeKb, blockSequence);

--- a/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
+++ b/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
@@ -117,4 +117,9 @@ public class SlackManager implements BMObserver {
         Boolean worked = postMsg2OurChannel(msg);
         System.err.println("Returned boolean from sending msg is " + worked);
     }
+
+    @Override
+    public Boolean isUpdated() {
+        return null;
+    }
 }

--- a/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
+++ b/src/main/java/edu/touro/mco152/bm/externalsys/SlackManager.java
@@ -26,13 +26,16 @@ import java.io.IOException;
 public class SlackManager implements BMObserver {
     private static Slack slack = null;  // obtain/keep one copy of expensive item
     public DiskRun diskRun;
+
     /**
      * Token for use with Slack API, representing info about our bot/app/channel.
      * If the token is a bot token, it starts with `xoxb-` while if it's a user token, it starts with `xoxp-`
      * This should really come from one of the badbm properties files, or from System.getenv()
      */
-    private final String token = "xoxb-121008389125-1115203038051-sUdT3T2GJQ4aLZDVHjazQgxC";
-    /**
+    // This token does not work anymore. (Not so)Thankfully, a classmate merged one to main before I could!
+    // Renamed from 'token' -> 'dummyToken'.
+    private final String token = "xoxb-8359216899-1017803038051-sT3T2GJQ4aLZDVHjazQgxC";
+    /**Ud
      * The channel we will send all our messages to
      */
     private final String ourChannel = "mco152_auto_notifications";

--- a/src/main/java/edu/touro/mco152/bm/persist/DBPersistenceObserver.java
+++ b/src/main/java/edu/touro/mco152/bm/persist/DBPersistenceObserver.java
@@ -10,9 +10,11 @@ import javax.persistence.EntityManager;
 public class DBPersistenceObserver implements BMObserver {
 
     DiskRun diskRun;
+    private Boolean hasBeenUpdated;
 
     public DBPersistenceObserver(DiskRun diskRun){
         this.diskRun = diskRun;
+        hasBeenUpdated = false;
     }
 
     @Override
@@ -21,6 +23,12 @@ public class DBPersistenceObserver implements BMObserver {
         em.getTransaction().begin();
         em.persist(diskRun);
         em.getTransaction().commit();
+        hasBeenUpdated = true;
+    }
+
+    @Override
+    public Boolean isUpdated() {
+        return hasBeenUpdated;
     }
 
 }

--- a/src/main/java/edu/touro/mco152/bm/ui/Gui.java
+++ b/src/main/java/edu/touro/mco152/bm/ui/Gui.java
@@ -31,9 +31,11 @@ public final class Gui implements BMObserver {
     public static JProgressBar progressBar = null;
     public static RunPanel runPanel = null;
     public DiskRun diskRun;
+    private Boolean hasBeenUpdated;
 
     public Gui(DiskRun diskRun){
         this.diskRun = diskRun;
+        hasBeenUpdated = false;
     }
 
     public static ChartPanel createChartPanel() {
@@ -148,5 +150,11 @@ public final class Gui implements BMObserver {
     @Override
     public void update() {
         runPanel.addRun(diskRun);
+        hasBeenUpdated = true;
+    }
+
+    @Override
+    public Boolean isUpdated() {
+        return hasBeenUpdated;
     }
 }

--- a/src/test/java/edu/touro/mco152/bm/AppTest.java
+++ b/src/test/java/edu/touro/mco152/bm/AppTest.java
@@ -1,20 +1,20 @@
-package edu.touro.mco152.bm.command;
+package edu.touro.mco152.bm;
 
-import edu.touro.mco152.bm.*;
 import edu.touro.mco152.bm.ui.Gui;
 import edu.touro.mco152.bm.ui.MainFrame;
-import java.io.File;
-import java.util.Properties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.util.Properties;
+
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ExecutorAndCommandTest {
+public class AppTest {
 
     // Arrange
     NonSwingBenchmark nonSwingBenchmark;
-    BenchmarkClient bmClient;
+    BenchmarkClient bmClientTest;
 
     @BeforeAll
     /**
@@ -52,38 +52,29 @@ public class ExecutorAndCommandTest {
     }
 
     /**
-     * writeCommand tests the boolean return value from BMWriteActionCommandCenter.execute()
+     * tests to initialize the program without gui
      */
     @Test
-    public void writeBMTest(){
-        // Arrange
-        setupDefaultAsPerProperties();
+    public void main_Test(){
+        // - APP
         // Act
-        nonSwingBenchmark = new NonSwingBenchmark("write");
+        setupDefaultAsPerProperties();
         // Assert
-        assertEquals("write", nonSwingBenchmark.readOrWrite);
-        assertTrue(nonSwingBenchmark.progressBool);
-        assertEquals(0, nonSwingBenchmark.currentProgress);
-        // ~ Act Again
-        bmClient = new BenchmarkClient(nonSwingBenchmark);
+        assertTrue(App.writeTest);
+
+        // NonSwingBenchmark implementation of UserInterface.
+        NonSwingBenchmark nonSwingBenchmark = new NonSwingBenchmark();
+        // Test in NonSwingBMTest class.
+        NonSwingBenchMarkTest nonSwingBenchMarkTest = new NonSwingBenchMarkTest();
+        nonSwingBenchMarkTest.nonSwingBMTemp = nonSwingBenchmark;
+        nonSwingBenchMarkTest.test_init();
+
+        // bmClient test "replica" of DiskWorker from main.
+        BenchmarkClient bmClient = new BenchmarkClient(nonSwingBenchmark);
+        // execute bmClient from NonSwingBenchmark
         bmClient.executionDelegate();
+
+
     }
 
-    /**
-     * readCommand tests the boolean return value from BMReadActionCommandCenter.execute()
-     */
-    @Test
-    public void readBMTest(){
-        // Arrange
-        setupDefaultAsPerProperties();
-        // Act
-        nonSwingBenchmark = new NonSwingBenchmark("read");
-        // Assert
-        assertEquals("read", nonSwingBenchmark.readOrWrite);
-        assertTrue(nonSwingBenchmark.progressBool);
-        assertEquals(0, nonSwingBenchmark.currentProgress);
-        // ~ Act Again
-        bmClient = new BenchmarkClient(nonSwingBenchmark);
-        bmClient.executionDelegate();
-    }
 }

--- a/src/test/java/edu/touro/mco152/bm/BenchmarkClient.java
+++ b/src/test/java/edu/touro/mco152/bm/BenchmarkClient.java
@@ -6,6 +6,9 @@ package edu.touro.mco152.bm;
  *  writeBMLogicNoSwing or readBMLogicNoSwing
  */
 
+import edu.touro.mco152.bm.command.BMCommandCenter;
+import edu.touro.mco152.bm.command.BMReadActionCommandCenter;
+import edu.touro.mco152.bm.command.BMWriteActionCommandCenter;
 import edu.touro.mco152.bm.persist.DiskRun;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +18,8 @@ public class BenchmarkClient {
 
     // Arrange
     private static UserInterface userInterface;
+    public static BMCommandCenter bmCommand;
+    public static CommandExecutor commandExecutor;
     // final command parameter values defined:
     public static final int numOfMark = 50;
     public static final int numOfBlocks = 64;
@@ -46,11 +51,12 @@ public class BenchmarkClient {
     @Test
     public static boolean writeBMLogicNoSwing(){
         // Act
-        CommandExecutor commandExecutor = new CommandExecutor(userInterface, "write");
-        commandExecutor.setCustomBMParams(numOfMark, numOfBlocks, blockSizeKb, blockSequence);
+        bmCommand = new BMWriteActionCommandCenter(userInterface, App.numOfMarks, App.numOfBlocks, App.blockSizeKb,
+                App.blockSequence);
+        commandExecutor = new CommandExecutor(bmCommand);
         // Assert
-        assertTrue(commandExecutor.executeBMCommandObject());
-        return commandExecutor.executeBMCommandObject();
+        assertTrue(commandExecutor.executeLogicDelegate());
+        return commandExecutor.executeLogicDelegate();
     }
 
     /**
@@ -60,10 +66,11 @@ public class BenchmarkClient {
     @Test
     public static boolean readBMLogicNoSwing(){
         // Act
-        CommandExecutor commandExecutor = new CommandExecutor(userInterface, "read");
-        commandExecutor.setCustomBMParams(numOfMark, numOfBlocks, blockSizeKb, blockSequence);
+        bmCommand = new BMReadActionCommandCenter(userInterface, App.numOfMarks, App.numOfBlocks, App.blockSizeKb,
+                App.blockSequence);
+        commandExecutor = new CommandExecutor(bmCommand);
         // Assert
-        assertTrue(commandExecutor.executeBMCommandObject());
-        return commandExecutor.executeBMCommandObject();
+        assertTrue(commandExecutor.executeLogicDelegate());
+        return commandExecutor.executeLogicDelegate();
     }
 }

--- a/src/test/java/edu/touro/mco152/bm/BenchmarkClientTest.java
+++ b/src/test/java/edu/touro/mco152/bm/BenchmarkClientTest.java
@@ -1,0 +1,75 @@
+package edu.touro.mco152.bm;
+
+import edu.touro.mco152.bm.ui.Gui;
+import edu.touro.mco152.bm.ui.MainFrame;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BenchmarkClientTest {
+
+    static BenchmarkClient bmClient;
+
+    @BeforeAll
+    /**
+     * Bruteforce setup of static classes/fields to allow DiskWorker to run.
+     *
+     * @author lcmcohen
+     */
+    static void setupDefaultAsPerProperties() {
+        /// Do the minimum of what  App.init() would do to allow to run.
+        Gui.mainFrame = new MainFrame();
+        App.p = new Properties();
+        App.loadConfig();
+        System.out.println(App.getConfigString());
+        Gui.progressBar = Gui.mainFrame.getProgressBar(); //must be set or get Nullptr
+
+        // configure the embedded DB in .jDiskMark
+        System.setProperty("derby.system.home", App.APP_CACHE_DIR);
+
+        // code from startBenchmark
+        //4. create data dir reference
+        App.dataDir = new File(App.locationDir.getAbsolutePath() + File.separator + App.DATADIRNAME);
+
+        //5. remove existing test data if exist
+        if (App.dataDir.exists()) {
+            if (App.dataDir.delete()) {
+                App.msg("removed existing data dir");
+            } else {
+                App.msg("unable to remove existing data dir");
+            }
+        }
+        else
+        {
+            App.dataDir.mkdirs(); // create data dir if not already present
+        }
+    }
+
+    @Test
+    public static void checkWriteAndRead(){
+        // Arrange
+        setupDefaultAsPerProperties();
+
+        // Act
+        NonSwingBenchmark nonSwingBenchmark = new NonSwingBenchmark();
+        bmClient = new BenchmarkClient(nonSwingBenchmark);
+
+        // Assert
+        assertFalse(BenchmarkClient.writeTestComplete);
+        assertFalse(BenchmarkClient.readTestComplete);
+
+        // Act
+        bmClient.executionDelegate();
+
+        // Assert
+        assertTrue(BenchmarkClient.writeTestComplete);
+        assertTrue(BenchmarkClient.readTestComplete);
+
+    }
+
+}

--- a/src/test/java/edu/touro/mco152/bm/ExecutorTest.java
+++ b/src/test/java/edu/touro/mco152/bm/ExecutorTest.java
@@ -1,0 +1,72 @@
+package edu.touro.mco152.bm;
+
+
+import edu.touro.mco152.bm.ui.Gui;
+import edu.touro.mco152.bm.ui.MainFrame;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExecutorTest {
+
+    public CommandExecutor commandExecutor;
+
+    public ExecutorTest(CommandExecutor commandExecutor) {
+        this.commandExecutor = commandExecutor;
+    }
+
+    @BeforeAll
+    /**
+     * Bruteforce setup of static classes/fields to allow DiskWorker to run.
+     *
+     * @author lcmcohen
+     */
+    static void setupDefaultAsPerProperties() {
+        /// Do the minimum of what  App.init() would do to allow to run.
+        Gui.mainFrame = new MainFrame();
+        App.p = new Properties();
+        App.loadConfig();
+        System.out.println(App.getConfigString());
+        Gui.progressBar = Gui.mainFrame.getProgressBar(); //must be set or get Nullptr
+
+        // configure the embedded DB in .jDiskMark
+        System.setProperty("derby.system.home", App.APP_CACHE_DIR);
+
+        // code from startBenchmark
+        //4. create data dir reference
+        App.dataDir = new File(App.locationDir.getAbsolutePath() + File.separator + App.DATADIRNAME);
+
+        //5. remove existing test data if exist
+        if (App.dataDir.exists()) {
+            if (App.dataDir.delete()) {
+                App.msg("removed existing data dir");
+            } else {
+                App.msg("unable to remove existing data dir");
+            }
+        }
+        else
+        {
+            App.dataDir.mkdirs(); // create data dir if not already present
+        }
+    }
+
+    @Test
+    public Boolean test_ifExecuted(){
+        assertTrue(commandExecutor.wasExecuted);
+        return true;
+    }
+
+    @AfterAll
+    public void checkListForUpdateBooleans(){
+        ArrayList<BMObserver> listOfObservers = commandExecutor.getObserverDelegate();
+        for(BMObserver observer : listOfObservers){
+            assertTrue(observer.isUpdated());
+        }
+    }
+}

--- a/src/test/java/edu/touro/mco152/bm/NonSwingBenchMarkTest.java
+++ b/src/test/java/edu/touro/mco152/bm/NonSwingBenchMarkTest.java
@@ -1,0 +1,60 @@
+package edu.touro.mco152.bm;
+
+import edu.touro.mco152.bm.ui.Gui;
+import edu.touro.mco152.bm.ui.MainFrame;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NonSwingBenchMarkTest {
+
+    public NonSwingBenchmark nonSwingBMTemp = new NonSwingBenchmark();
+
+    @BeforeAll
+    /**
+     * Bruteforce setup of static classes/fields to allow DiskWorker to run.
+     *
+     * @author lcmcohen
+     */
+    static void setupDefaultAsPerProperties() {
+        /// Do the minimum of what  App.init() would do to allow to run.
+        Gui.mainFrame = new MainFrame();
+        App.p = new Properties();
+        App.loadConfig();
+        System.out.println(App.getConfigString());
+        Gui.progressBar = Gui.mainFrame.getProgressBar(); //must be set or get Nullptr
+
+        // configure the embedded DB in .jDiskMark
+        System.setProperty("derby.system.home", App.APP_CACHE_DIR);
+
+        // code from startBenchmark
+        //4. create data dir reference
+        App.dataDir = new File(App.locationDir.getAbsolutePath() + File.separator + App.DATADIRNAME);
+
+        //5. remove existing test data if exist
+        if (App.dataDir.exists()) {
+            if (App.dataDir.delete()) {
+                App.msg("removed existing data dir");
+            } else {
+                App.msg("unable to remove existing data dir");
+            }
+        }
+        else
+        {
+            App.dataDir.mkdirs(); // create data dir if not already present
+        }
+    }
+
+    @Test
+    public void test_init(){
+        setupDefaultAsPerProperties();
+        assertEquals(nonSwingBMTemp.currentProgress, 0);
+        assertTrue(nonSwingBMTemp.progressBool);
+    }
+
+}

--- a/src/test/java/edu/touro/mco152/bm/NonSwingBenchmark.java
+++ b/src/test/java/edu/touro/mco152/bm/NonSwingBenchmark.java
@@ -8,24 +8,10 @@ import java.beans.PropertyChangeListener;
  * own class.
  */
 public class NonSwingBenchmark implements UserInterface{
-
-    // String variable so executeBenchmark() knows which logic method it should run.
-    public String readOrWrite;
     // Boolean variable to determine whether the benchmark is cancelled or not.
-    public boolean progressBool;
+    public boolean progressBool = true;
     // Integer variable in case we need to set isCancelled to false and carry on with logic execution.
-    public int currentProgress;
-
-    /**
-     * Instantiation requires a "read" or "write" string.
-     * @param readOrWrite string to determine read/write
-     */
-    public NonSwingBenchmark(String readOrWrite){
-        this.readOrWrite = readOrWrite;
-        progressBool = true;
-        currentProgress = 0;
-    }
-
+    public int currentProgress = 0;
 
     @Override
     public void registerPropertyChangeListener(PropertyChangeListener listener) {
@@ -37,11 +23,8 @@ public class NonSwingBenchmark implements UserInterface{
      */
     @Override
     public void executeBenchMark() {
-        if(readOrWrite.equals("write")){
-            BenchmarkClient.writeBMLogicNoSwing();
-        }
-        else if(readOrWrite.equals("read")){
-            BenchmarkClient.readBMLogicNoSwing();
+        if(BenchmarkClient.doBMLogic_NoSwing()){
+            System.out.println(" FINISHED EXECUTING BM");
         }
     }
 
@@ -63,9 +46,7 @@ public class NonSwingBenchmark implements UserInterface{
         if(x == 100){
             progressBool = false;
         }
-        else{
-            currentProgress = x;
-        }
+        currentProgress = x;
     }
 
     @Override


### PR DESCRIPTION
(1) Refactored BMCommandCenter, BMReadCommand and BMWriteCommand dependencies back into DiskWorker and BenchMarkClient.
(2) Cleaned up javadoc and comment in BMCommandCenter.
(3) Refactored CommandExecutor to accept a generic BMCommand (observable) object, making the code cleaner with greater potential.